### PR TITLE
[SRE-2199] Copy scripts to support Redis Sentinel bootstrapping in Kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.0-0c4e97a-1
+
+* Add bash scripts to run Redis Sentinel easily in Kubernetes.
+
 ## 0.0.0-0c4e97a
 
 * Package latest version of Redis Roaring into a Docker image.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,3 @@
 FROM aviggiano/redis-roaring@sha256:0c4e97accbf6821b828b46aef0b77572b6d3866b6fb3b17e9f0ffd527f8cbeb3
+
+COPY --from=zappi/redis:6.2.6 /opt/redis/scripts/ /opt/redis/scripts/

--- a/README.md
+++ b/README.md
@@ -1,21 +1,32 @@
-# Redis Roaring
+# Docker Redis Roaring
 
-Roaring Bitmaps for Redis
+## Introduction
 
-## Intro
-
-This project uses the [CRoaring](https://github.com/RoaringBitmap/CRoaring)
+Redis Roaring uses the [CRoaring](https://github.com/RoaringBitmap/CRoaring)
 library to implement roaring bitmap commands for Redis. These commands can have
 the same performance as redis' native bitmaps for *O(1)* operations and be up to
 8x faster for *O(N)* calls, according to microbenchmarks, while consuming less
 memory than their uncompressed counterparts (benchmark pending).
 
-See upstream project at [github.com/aviggiano/redis-roaring](https://github.com/aviggiano/redis-roaring) for more details.
+## Features
 
-## Docker
+* Based off latest version of Redis Roaring.
+* Included bash scripts to run Redis Sentinel easily in Kubernetes.
 
-To run the service in Docker use:
+## Usage
+
+To run a simple setup of a single Redis Roaring container in Docker use:
 
 ```bash
 docker run -p 6379:6379 zappi/redis-roaring:<tag>
 ```
+
+And to run a more complex setup using Redis Sentinel in Kubernetes use the
+reference [example manifests here][1]. Replace `zappi/redis:<tag>` with
+`zappi/redis-roaring:<tag>` and run:
+
+```bash
+kubectl apply -f examples/kubernetes/
+```
+
+[1]: https://github.com/Intellection/docker-redis/tree/main/examples/kubernetes


### PR DESCRIPTION
So that we can use [Redis Sentinel](https://redis.io/topics/sentinel) to run a highly available [Redis Roaring](https://github.com/aviggiano/redis-roaring) setup.

### References

* https://github.com/Intellection/docker-redis/pull/1